### PR TITLE
Squashing issue related to ipv6 during layer installation

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -51,6 +51,8 @@ RUN apt install -qy apt-transport-https lsb-release ca-certificates \
 
 ## Ruby install
 RUN apt-get install -qy gnupg build-essential \
+  && mkdir ~/.gnupg \
+  && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf \
   && gpg --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB \
   && curl -sSL https://get.rvm.io | bash -s stable \
   && source /etc/profile.d/rvm.sh \


### PR DESCRIPTION
- Disabling ipv6 in gpg's config. file as if the host does not have ipv6 enabled some key servers might fail to connect causing the docker image build to fail